### PR TITLE
feat/Do not use reflect package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Install
 
-`go get github.com/nspcc-dev/hrw`
+`go get github.com/nspcc-dev/hrw/v2`
 
 ## Benchmark:
 
@@ -42,7 +42,7 @@ package main
 import (
 	"fmt"
 	
-	"github.com/nspcc-dev/hrw"
+	"github.com/nspcc-dev/hrw/v2"
 )
 
 type hashString string

--- a/README.md
+++ b/README.md
@@ -45,27 +45,30 @@ import (
 	"github.com/nspcc-dev/hrw"
 )
 
+type hashString string
+
+func (h hashString) Hash() uint64 {
+	return hrw.WrapBytes([]byte(h)).Hash()
+}
+
 func main() {
 	// given a set of servers
-	servers := []string{
-		"one.example.com",
-		"two.example.com",
-		"three.example.com",
-		"four.example.com",
-		"five.example.com",
-		"six.example.com",
+	servers := []hrw.Hashable{
+		hashString("one.example.com"),
+		hashString("two.example.com"),
+		hashString("three.example.com"),
+		hashString("four.example.com"),
+		hashString("five.example.com"),
+		hashString("six.example.com"),
 	}
 
 	// HRW can consistently select a uniformly-distributed set of servers for
 	// any given key
-	var (
-		key = []byte("/examples/object-key")
-		h   = hrw.Hash(key)
-	)
+	var key = []byte("/examples/object-key")
 
-	hrw.SortSliceByValue(servers, h)
+	hrw.Sort(servers, hrw.WrapBytes(key))
 	for id := range servers {
-		fmt.Printf("trying GET %s%s\n", servers[id], key)
+		fmt.Printf("trying GET %s%s\n", servers[id], string(key))
 	}
 
 	// Output:

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,67 @@
+package hrw
+
+import "testing"
+
+func BenchmarkSort_fnv_10(b *testing.B) {
+	_ = benchmarkSort(b, 10, testKey)
+}
+
+func BenchmarkSort_fnv_100(b *testing.B) {
+	_ = benchmarkSort(b, 100, testKey)
+}
+
+func BenchmarkSort_fnv_1000(b *testing.B) {
+	_ = benchmarkSort(b, 1000, testKey)
+}
+
+func BenchmarkSortByWeight_fnv_10(b *testing.B) {
+	_ = benchmarkSortByWeight(b, 10, testKey)
+}
+
+func BenchmarkSortByWeight_fnv_100(b *testing.B) {
+	_ = benchmarkSortByWeight(b, 100, testKey)
+}
+
+func BenchmarkSortByWeight_fnv_1000(b *testing.B) {
+	_ = benchmarkSortByWeight(b, 1000, testKey)
+}
+
+func benchmarkSort(b *testing.B, n int, object []byte) uint64 {
+	servers := make([]hashableUint64, n)
+	for i := uint64(0); i < uint64(len(servers)); i++ {
+		servers[i] = hashableUint64(i)
+	}
+
+	oHash := hashableUint64(WrapBytes(object).Hash())
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	var x uint64
+	for i := 0; i < b.N; i++ {
+		Sort(servers, oHash)
+		x += servers[0].Hash()
+	}
+	return x
+}
+
+func benchmarkSortByWeight(b *testing.B, n int, object []byte) uint64 {
+	servers := make([]hashableUint64, n)
+	weights := make([]float64, n)
+	for i := uint64(0); i < uint64(len(servers)); i++ {
+		weights[i] = float64(uint64(n)-i) / float64(n)
+		servers[i] = hashableUint64(i)
+	}
+
+	oHash := hashableUint64(WrapBytes(object).Hash())
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	var x uint64
+	for i := 0; i < b.N; i++ {
+		SortWeighted(servers, weights, oHash)
+		x += servers[0].Hash()
+	}
+	return x
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nspcc-dev/hrw
+module github.com/nspcc-dev/hrw/v2
 
 go 1.19
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/stretchr/testify v1.8.4
 	github.com/twmb/murmur3 v1.1.8
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
 github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/hrw.go
+++ b/hrw.go
@@ -1,37 +1,104 @@
 // Package hrw implements Rendezvous hashing.
-// http://en.wikipedia.org/wiki/Rendezvous_hashing.
+// https://en.wikipedia.org/wiki/Rendezvous_hashing.
 package hrw
 
 import (
-	"encoding/binary"
-	"errors"
-	"math"
-	"reflect"
 	"sort"
 
 	"github.com/twmb/murmur3"
+	"golang.org/x/exp/constraints"
 )
 
-type (
-	// Hasher interface used by SortSliceByValue.
-	Hasher interface{ Hash() uint64 }
+// Hashable is something that can be hashed.
+type Hashable interface{ Hash() uint64 }
 
-	sorter struct {
-		l    int
-		less func(i, j int) bool
-		swap func(i, j int)
+// HashableBytes implements Hashable interface over
+// raw data. Use [WrapBytes] to instantiate a correct
+// byte slice wrapper.
+type HashableBytes []byte
+
+func (h HashableBytes) Hash() uint64 {
+	return murmur3.Sum64(h)
+}
+
+// WrapBytes creates [HashableBytes] that implements
+// [Hashable] interface over a raw data.
+// Can be used for [Sort] and [SortWeighted].
+func WrapBytes(b []byte) HashableBytes {
+	return b
+}
+
+// Sort defines and sorts the scores for the provided hashable
+// entities against the provided hashable object (in its general
+// sense).
+// See [Hashable], [HashableBytes] and https://en.wikipedia.org/wiki/Rendezvous_hashing.
+func Sort[V, P Hashable](vv []V, object P) {
+	oHash := object.Hash()
+
+	var s sliceToSort[V, uint64]
+	s.s = vv
+	s.distances = make([]uint64, len(vv))
+
+	for i := range vv {
+		s.distances[i] = distance(vv[i].Hash(), oHash)
 	}
-)
 
-// Boundaries of valid normalized weights.
-const (
-	NormalizedMaxWeight = 1.0
-	NormalizedMinWeight = 0.0
-)
+	sort.Stable(&s)
+}
 
-func (s *sorter) Len() int           { return s.l }
-func (s *sorter) Less(i, j int) bool { return s.less(i, j) }
-func (s *sorter) Swap(i, j int)      { s.swap(i, j) }
+// SortWeighted is the same as [Sort] but allows using weights for
+// a slice being sorted. A weight is applied to the corresponding
+// element's score in the resulting slice. A weight allows modifying
+// the default (equal to any element) probability of an element to
+// win HRW sorting.
+// Value slice's length and weight slice's length MUST be the same.
+// Weights MUST be in [0.0; 1.0] range.
+func SortWeighted[V, P Hashable, W constraints.Float](vv []V, weights []W, object P) {
+	if len(vv) != len(weights) {
+		return
+	}
+
+	if allSameF(weights) {
+		Sort(vv, object)
+		return
+	}
+
+	oHash := object.Hash()
+
+	var s sliceToSort[V, W]
+	s.s = vv
+	s.distances = make([]W, len(vv))
+
+	for i := range vv {
+		// the distance is a bad characteristic in our case (we sort in ascending order)
+		// so a bigger weight should lower the distance more
+		s.distances[i] = W(distance(vv[i].Hash(), oHash)) / weights[i]
+	}
+
+	sort.Stable(&s)
+}
+
+type distancesValue interface {
+	constraints.Unsigned | constraints.Float
+}
+
+type sliceToSort[V any, W distancesValue] struct {
+	s         []V
+	distances []W
+}
+
+func (s *sliceToSort[V, _]) Len() int {
+	return len(s.s)
+}
+
+func (s *sliceToSort[V, _]) Less(i, j int) bool {
+	return s.distances[i] < s.distances[j]
+}
+
+func (s *sliceToSort[V, _]) Swap(i, j int) {
+	s.s[i], s.s[j] = s.s[j], s.s[i]
+	s.distances[i], s.distances[j] = s.distances[j], s.distances[i]
+}
 
 func distance(x uint64, y uint64) uint64 {
 	acc := x ^ y
@@ -45,236 +112,7 @@ func distance(x uint64, y uint64) uint64 {
 	return acc
 }
 
-// Hash uses murmur3 hash to return uint64.
-func Hash(key []byte) uint64 {
-	return murmur3.Sum64(key)
-}
-
-// Sort receive nodes and hash, and sort it by distance.
-func Sort(nodes []uint64, hash uint64) []uint64 {
-	l := len(nodes)
-	sorted := make([]uint64, l)
-	dist := make([]uint64, l)
-	for i := range nodes {
-		sorted[i] = uint64(i)
-		dist[i] = distance(nodes[i], hash)
-	}
-
-	sort.Slice(sorted, func(i, j int) bool {
-		return dist[sorted[i]] < dist[sorted[j]]
-	})
-	return sorted
-}
-
-// SortByWeight receive nodes, weights and hash, and sort it by distance * weight.
-func SortByWeight(nodes []uint64, weights []float64, hash uint64) []uint64 {
-	result := make([]uint64, len(nodes))
-	copy(nodes, result)
-	sortByWeight(len(nodes), false, nodes, weights, hash, reflect.Swapper(result))
-	return result
-}
-
-// SortSliceByValue received []T and hash to sort by value-distance.
-func SortSliceByValue(slice interface{}, hash uint64) {
-	rule := prepareRule(slice)
-	if rule != nil {
-		swap := reflect.Swapper(slice)
-		sortByDistance(len(rule), false, rule, hash, swap)
-	}
-}
-
-// SortSliceByWeightValue received []T, weights and hash to sort by value-distance * weights.
-func SortSliceByWeightValue(slice interface{}, weights []float64, hash uint64) {
-	rule := prepareRule(slice)
-	if rule != nil {
-		swap := reflect.Swapper(slice)
-		sortByWeight(reflect.ValueOf(slice).Len(), false, rule, weights, hash, swap)
-	}
-}
-
-// SortSliceByIndex received []T and hash to sort by index-distance.
-func SortSliceByIndex(slice interface{}, hash uint64) {
-	length := reflect.ValueOf(slice).Len()
-	swap := reflect.Swapper(slice)
-	sortByDistance(length, true, nil, hash, swap)
-}
-
-// SortSliceByWeightIndex received []T, weights and hash to sort by index-distance * weights.
-func SortSliceByWeightIndex(slice interface{}, weights []float64, hash uint64) {
-	length := reflect.ValueOf(slice).Len()
-	swap := reflect.Swapper(slice)
-	sortByWeight(length, true, nil, weights, hash, swap)
-}
-
-func prepareRule(slice interface{}) []uint64 {
-	t := reflect.TypeOf(slice)
-	if t.Kind() != reflect.Slice {
-		panic("HRW sort expects slice, got " + t.Kind().String())
-	}
-
-	var (
-		val    = reflect.ValueOf(slice)
-		length = val.Len()
-		rule   = make([]uint64, 0, length)
-	)
-
-	if length == 0 {
-		return nil
-	}
-
-	switch slice := slice.(type) {
-	case []int:
-		var key = make([]byte, 16)
-		for i := 0; i < length; i++ {
-			binary.BigEndian.PutUint64(key, uint64(slice[i]))
-			rule = append(rule, Hash(key))
-		}
-	case []uint:
-		var key = make([]byte, 16)
-		for i := 0; i < length; i++ {
-			binary.BigEndian.PutUint64(key, uint64(slice[i]))
-			rule = append(rule, Hash(key))
-		}
-	case []int8:
-		for i := 0; i < length; i++ {
-			key := byte(slice[i])
-			rule = append(rule, Hash([]byte{key}))
-		}
-	case []uint8:
-		for i := 0; i < length; i++ {
-			key := slice[i]
-			rule = append(rule, Hash([]byte{key}))
-		}
-	case []int16:
-		var key = make([]byte, 8)
-		for i := 0; i < length; i++ {
-			binary.BigEndian.PutUint16(key, uint16(slice[i]))
-			rule = append(rule, Hash(key))
-		}
-	case []uint16:
-		var key = make([]byte, 8)
-		for i := 0; i < length; i++ {
-			binary.BigEndian.PutUint16(key, slice[i])
-			rule = append(rule, Hash(key))
-		}
-	case []int32:
-		var key = make([]byte, 16)
-		for i := 0; i < length; i++ {
-			binary.BigEndian.PutUint32(key, uint32(slice[i]))
-			rule = append(rule, Hash(key))
-		}
-	case []uint32:
-		var key = make([]byte, 16)
-		for i := 0; i < length; i++ {
-			binary.BigEndian.PutUint32(key, slice[i])
-			rule = append(rule, Hash(key))
-		}
-	case []int64:
-		var key = make([]byte, 32)
-		for i := 0; i < length; i++ {
-			binary.BigEndian.PutUint64(key, uint64(slice[i]))
-			rule = append(rule, Hash(key))
-		}
-	case []uint64:
-		var key = make([]byte, 32)
-		for i := 0; i < length; i++ {
-			binary.BigEndian.PutUint64(key, slice[i])
-			rule = append(rule, Hash(key))
-		}
-	case []string:
-		for i := 0; i < length; i++ {
-			rule = append(rule, Hash([]byte(slice[i])))
-		}
-
-	default:
-		if _, ok := val.Index(0).Interface().(Hasher); !ok {
-			panic("slice elements must implement hrw.Hasher")
-		}
-
-		for i := 0; i < length; i++ {
-			h := val.Index(i).Interface().(Hasher)
-			rule = append(rule, h.Hash())
-		}
-	}
-	return rule
-}
-
-// ValidateWeights checks if weights are normalized between 0.0 and 1.0.
-func ValidateWeights(weights []float64) error {
-	for i := range weights {
-		if math.IsNaN(weights[i]) || weights[i] > NormalizedMaxWeight || weights[i] < NormalizedMinWeight {
-			return errors.New("weights are not normalized")
-		}
-	}
-	return nil
-}
-
-func newSorter(l int, byIndex bool, nodes []uint64, h uint64,
-	swap func(i, j int)) (*sorter, []int, []uint64) {
-	ind := make([]int, l)
-	dist := make([]uint64, l)
-	for i := 0; i < l; i++ {
-		ind[i] = i
-		dist[i] = getDistance(byIndex, i, nodes, h)
-	}
-
-	return &sorter{
-		l: l,
-		swap: func(i, j int) {
-			swap(i, j)
-			ind[i], ind[j] = ind[j], ind[i]
-		},
-	}, ind, dist
-}
-
-// sortByWeight sorts nodes by weight using provided swapper.
-// nodes contains hrw hashes. If it is nil, indices are used.
-func sortByWeight(l int, byIndex bool, nodes []uint64, weights []float64, hash uint64, swap func(i, j int)) {
-	// if all nodes have the same distance then sort uniformly
-	if allSameF64(weights) {
-		sortByDistance(l, byIndex, nodes, hash, swap)
-		return
-	}
-
-	s, ind, dist := newSorter(l, byIndex, nodes, hash, swap)
-	s.less = func(i, j int) bool {
-		ii, jj := ind[i], ind[j]
-		// `maxUint64 - distance` makes the shorter distance more valuable
-		// it is necessary for operation with normalized values
-		wi := float64(^uint64(0)-dist[ii]) * weights[ii]
-		wj := float64(^uint64(0)-dist[jj]) * weights[jj]
-		return wi > wj // higher distance must be placed lower to be first
-	}
-	sort.Sort(s)
-}
-
-// sortByDistance sorts nodes by hrw distance using provided swapper.
-// nodes contains hrw hashes. If it is nil, indices are used.
-func sortByDistance(l int, byIndex bool, nodes []uint64, hash uint64, swap func(i, j int)) {
-	s, ind, dist := newSorter(l, byIndex, nodes, hash, swap)
-	s.less = func(i, j int) bool {
-		return dist[ind[i]] < dist[ind[j]]
-	}
-	sort.Sort(s)
-}
-
-// getDistance return distance from nodes[i] to h.
-// If byIndex is true, nodes index is used.
-// Else if nodes[i] != nil, distance is calculated from this value.
-// Otherwise, and hash from node index is taken.
-func getDistance(byIndex bool, i int, nodes []uint64, h uint64) uint64 {
-	if nodes != nil {
-		return distance(nodes[i], h)
-	} else if byIndex {
-		return distance(uint64(i), h)
-	} else {
-		buf := make([]byte, 8)
-		binary.LittleEndian.PutUint64(buf, uint64(i))
-		return distance(Hash(buf), h)
-	}
-}
-
-func allSameF64(fs []float64) bool {
+func allSameF[W constraints.Float](fs []W) bool {
 	for i := range fs {
 		if fs[i] != fs[0] {
 			return false

--- a/hrw_test.go
+++ b/hrw_test.go
@@ -4,51 +4,37 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-	"math/rand"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-type (
-	hashString string
-	unknown    byte
-	slices     struct {
-		actual interface{}
-		expect interface{}
-	}
+type hashString string
 
-	Uint32Slice []uint32
-)
+func (h hashString) Hash() uint64 {
+	return WrapBytes([]byte(h)).Hash()
+}
 
 var testKey = []byte("0xff51afd7ed558ccd")
 
-func (p Uint32Slice) Len() int           { return len(p) }
-func (p Uint32Slice) Less(i, j int) bool { return p[i] < p[j] }
-func (p Uint32Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-
 func Example() {
 	// given a set of servers
-	servers := []string{
-		"one.example.com",
-		"two.example.com",
-		"three.example.com",
-		"four.example.com",
-		"five.example.com",
-		"six.example.com",
+	servers := []Hashable{
+		hashString("one.example.com"),
+		hashString("two.example.com"),
+		hashString("three.example.com"),
+		hashString("four.example.com"),
+		hashString("five.example.com"),
+		hashString("six.example.com"),
 	}
 
 	// HRW can consistently select a uniformly-distributed set of servers for
 	// any given key
-	var (
-		key = []byte("/examples/object-key")
-		h   = Hash(key)
-	)
+	var key = []byte("/examples/object-key")
 
-	SortSliceByValue(servers, h)
+	Sort(servers, WrapBytes(key))
 	for id := range servers {
-		fmt.Printf("trying GET %s%s\n", servers[id], key)
+		fmt.Printf("trying GET %s%s\n", servers[id], string(key))
 	}
 
 	// Output:
@@ -60,143 +46,27 @@ func Example() {
 	// trying GET four.example.com/examples/object-key
 }
 
-func (h hashString) Hash() uint64 {
-	return Hash([]byte(h))
+type hashableUint64 uint64
+
+func (h hashableUint64) Hash() uint64 {
+	return uint64(h)
 }
 
-func TestSortSliceByIndex(t *testing.T) {
-	actual := []string{"a", "b", "c", "d", "e", "f"}
-	expect := []string{"e", "a", "c", "f", "d", "b"}
-	hash := Hash(testKey)
-	SortSliceByIndex(actual, hash)
-	require.Equal(t, expect, actual)
-}
-
-func TestValidateWeights(t *testing.T) {
-	weights := []float64{10, 10, 10, 2, 2, 2}
-	err := ValidateWeights(weights)
-	require.Error(t, err)
-	weights = []float64{math.NaN(), 1, 1, 0.2, 0.2, 0.2}
-	err = ValidateWeights(weights)
-	require.Error(t, err)
-	weights = []float64{1, 1, 1, 0.2, 0.2, 0.2}
-	err = ValidateWeights(weights)
-	require.NoError(t, err)
-}
-
-func TestSortSliceByWeightIndex(t *testing.T) {
-	actual := []string{"a", "b", "c", "d", "e", "f"}
-	weights := []float64{1, 1, 1, 0.2, 0.2, 0.2}
-	expect := []string{"a", "c", "b", "e", "f", "d"}
-	hash := Hash(testKey)
-	SortSliceByWeightIndex(actual, weights, hash)
-	require.Equal(t, expect, actual)
-}
-
-func TestSortSliceByValue(t *testing.T) {
-	actual := []string{"a", "b", "c", "d", "e", "f"}
-	expect := []string{"d", "f", "c", "b", "a", "e"}
-	hash := Hash(testKey)
-	SortSliceByValue(actual, hash)
-	require.Equal(t, expect, actual)
-}
-
-func TestSortSliceByValueFail(t *testing.T) {
-	t.Run("empty slice", func(t *testing.T) {
-		var (
-			actual []int
-			hash   = Hash(testKey)
-		)
-		require.NotPanics(t, func() { SortSliceByValue(actual, hash) })
-	})
-
-	t.Run("must be slice", func(t *testing.T) {
-		actual := 10
-		hash := Hash(testKey)
-		require.Panics(t, func() { SortSliceByValue(actual, hash) })
-	})
-
-	t.Run("must 'fail' for unknown type", func(t *testing.T) {
-		actual := []unknown{1, 2, 3, 4, 5}
-		hash := Hash(testKey)
-		require.Panics(t, func() { SortSliceByValue(actual, hash) })
-	})
-}
-
-func TestSortSliceByValueHasher(t *testing.T) {
-	actual := []hashString{"a", "b", "c", "d", "e", "f"}
-	expect := []hashString{"d", "f", "c", "b", "a", "e"}
-	hash := Hash(testKey)
-	SortSliceByValue(actual, hash)
-	require.Equal(t, expect, actual)
-}
-
-func TestSortSliceByValueIntSlice(t *testing.T) {
-	cases := []slices{
-		{
-			actual: []int{0, 1, 2, 3, 4, 5},
-			expect: []int{2, 0, 5, 3, 1, 4},
-		},
-
-		{
-			actual: []uint{0, 1, 2, 3, 4, 5},
-			expect: []uint{2, 0, 5, 3, 1, 4},
-		},
-
-		{
-			actual: []int8{0, 1, 2, 3, 4, 5},
-			expect: []int8{5, 2, 1, 4, 0, 3},
-		},
-
-		{
-			actual: []uint8{0, 1, 2, 3, 4, 5},
-			expect: []uint8{5, 2, 1, 4, 0, 3},
-		},
-
-		{
-			actual: []int16{0, 1, 2, 3, 4, 5},
-			expect: []int16{1, 0, 3, 2, 4, 5},
-		},
-
-		{
-			actual: []uint16{0, 1, 2, 3, 4, 5},
-			expect: []uint16{1, 0, 3, 2, 4, 5},
-		},
-
-		{
-			actual: []int32{0, 1, 2, 3, 4, 5},
-			expect: []int32{5, 1, 2, 0, 3, 4},
-		},
-
-		{
-			actual: []uint32{0, 1, 2, 3, 4, 5},
-			expect: []uint32{5, 1, 2, 0, 3, 4},
-		},
-
-		{
-			actual: []int64{0, 1, 2, 3, 4, 5},
-			expect: []int64{5, 3, 0, 1, 4, 2},
-		},
-
-		{
-			actual: []uint64{0, 1, 2, 3, 4, 5},
-			expect: []uint64{5, 3, 0, 1, 4, 2},
-		},
+func wrapUint64(uu []uint64) []Hashable {
+	res := make([]Hashable, 0, len(uu))
+	for _, u := range uu {
+		res = append(res, hashableUint64(u))
 	}
-	hash := Hash(testKey)
 
-	for _, tc := range cases {
-		SortSliceByValue(tc.actual, hash)
-		require.Equal(t, tc.expect, tc.actual)
-	}
+	return res
 }
 
 func TestSort(t *testing.T) {
-	nodes := []uint64{1, 2, 3, 4, 5}
-	hash := Hash(testKey)
-	actual := Sort(nodes, hash)
-	expected := []uint64{3, 1, 4, 2, 0}
-	require.Equal(t, expected, actual)
+	nodes := wrapUint64([]uint64{1, 2, 3, 4, 5})
+	expected := wrapUint64([]uint64{4, 2, 5, 3, 1})
+
+	Sort(nodes, WrapBytes(testKey))
+	require.Equal(t, expected, nodes)
 }
 
 func TestDistribution(t *testing.T) {
@@ -214,7 +84,7 @@ func TestDistribution(t *testing.T) {
 		var (
 			i      uint64
 			nodes  [size]uint64
-			counts = make(map[uint64]uint64, size)
+			counts = make(map[Hashable]uint64, size)
 			key    = make([]byte, 16)
 		)
 
@@ -224,343 +94,15 @@ func TestDistribution(t *testing.T) {
 
 		for i = 0; i < keys; i++ {
 			binary.BigEndian.PutUint64(key, i+size)
-			hash := Hash(key)
-			counts[Sort(nodes[:], hash)[0]]++
+			nodesHashed := wrapUint64(nodes[:])
+			Sort(nodesHashed, WrapBytes(key))
+			counts[nodesHashed[0]]++
 		}
 
 		var chi2 float64
 		mean := float64(keys) / float64(size)
 		delta := mean * percent
 		for node, count := range counts {
-			d := mean - float64(count)
-			chi2 += math.Pow(float64(count)-mean, 2) / mean
-			require.True(t, d < delta && (0-d) < delta,
-				"Node %d received %d keys, expected %.0f (+/- %.2f)", node, count, mean, delta)
-		}
-		require.True(t, chi2 < chiTable[size-1],
-			"Chi2 condition for .9 is not met (expected %.2f <= %.2f)", chi2, chiTable[size-1])
-	})
-
-	t.Run("sortByIndex", func(t *testing.T) {
-		var (
-			i      uint64
-			a, b   [size]uint64
-			counts = make(map[uint64]int, size)
-			key    = make([]byte, 16)
-		)
-
-		for i = 0; i < size; i++ {
-			a[i] = i
-		}
-
-		for i = 0; i < keys; i++ {
-			copy(b[:], a[:])
-
-			binary.BigEndian.PutUint64(key, i+size)
-			hash := Hash(key)
-			SortSliceByIndex(b[:], hash)
-			counts[b[0]]++
-		}
-
-		var chi2 float64
-		mean := float64(keys) / float64(size)
-		delta := mean * percent
-		for node, count := range counts {
-			d := mean - float64(count)
-			chi2 += math.Pow(float64(count)-mean, 2) / mean
-			require.True(t, d < delta && (0-d) < delta,
-				"Node %d received %d keys, expected %.0f (+/- %.2f)", node, count, mean, delta)
-		}
-		require.True(t, chi2 < chiTable[size-1],
-			"Chi2 condition for .9 is not met (expected %.2f <= %.2f)", chi2, chiTable[size-1])
-	})
-
-	t.Run("sortByValue", func(t *testing.T) {
-		var (
-			i      uint64
-			a, b   [size]int
-			counts = make(map[int]int, size)
-			key    = make([]byte, 16)
-		)
-
-		for i = 0; i < size; i++ {
-			a[i] = int(i)
-		}
-
-		for i = 0; i < keys; i++ {
-			copy(b[:], a[:])
-			binary.BigEndian.PutUint64(key, i+size)
-			hash := Hash(key)
-			SortSliceByValue(b[:], hash)
-			counts[b[0]]++
-		}
-
-		var chi2 float64
-		mean := float64(keys) / float64(size)
-		delta := mean * percent
-		for node, count := range counts {
-			d := mean - float64(count)
-			chi2 += math.Pow(float64(count)-mean, 2) / mean
-			require.True(t, d < delta && (0-d) < delta,
-				"Node %d received %d keys, expected %.0f (+/- %.2f)", node, count, mean, delta)
-		}
-		require.True(t, chi2 < chiTable[size-1],
-			"Chi2 condition for .9 is not met (expected %.2f <= %.2f)", chi2, chiTable[size-1])
-	})
-
-	t.Run("sortByStringValue", func(t *testing.T) {
-		var (
-			i      uint64
-			a, b   [size]string
-			counts = make(map[string]int, size)
-			key    = make([]byte, 16)
-		)
-
-		for i = 0; i < size; i++ {
-			a[i] = strconv.FormatUint(i, 10)
-		}
-
-		for i = 0; i < keys; i++ {
-			copy(b[:], a[:])
-			binary.BigEndian.PutUint64(key, i+size)
-			hash := Hash(key)
-			SortSliceByValue(b[:], hash)
-			counts[b[0]]++
-		}
-
-		var chi2 float64
-		mean := float64(keys) / float64(size)
-		delta := mean * percent
-		for node, count := range counts {
-			d := mean - float64(count)
-			chi2 += math.Pow(float64(count)-mean, 2) / mean
-			require.True(t, d < delta && (0-d) < delta,
-				"Node %d received %d keys, expected %.0f (+/- %.2f)", node, count, mean, delta)
-		}
-		require.True(t, chi2 < chiTable[size-1],
-			"Chi2 condition for .9 is not met (expected %.2f <= %.2f)", chi2, chiTable[size-1])
-	})
-
-	t.Run("sortByInt32Value", func(t *testing.T) {
-		var (
-			i      uint64
-			a, b   [size]int32
-			counts = make(map[int32]int, size)
-			key    = make([]byte, 16)
-		)
-
-		for i = 0; i < size; i++ {
-			a[i] = int32(i)
-		}
-
-		for i = 0; i < keys; i++ {
-			copy(b[:], a[:])
-			binary.BigEndian.PutUint64(key, i+size)
-			hash := Hash(key)
-			SortSliceByValue(b[:], hash)
-			counts[b[0]]++
-		}
-
-		var chi2 float64
-		mean := float64(keys) / float64(size)
-		delta := mean * percent
-		for node, count := range counts {
-			d := mean - float64(count)
-			chi2 += math.Pow(float64(count)-mean, 2) / mean
-			require.True(t, d < delta && (0-d) < delta,
-				"Node %d received %d keys, expected %.0f (+/- %.2f)", node, count, mean, delta)
-		}
-		require.True(t, chi2 < chiTable[size-1],
-			"Chi2 condition for .9 is not met (expected %.2f <= %.2f)", chi2, chiTable[size-1])
-	})
-
-	t.Run("sortByWeightValue", func(t *testing.T) {
-		var (
-			i            uint64
-			a, b, result [size]int
-			w            [size]float64
-			key          = make([]byte, 16)
-		)
-
-		for i = 0; i < size; i++ {
-			a[i] = int(i)
-			w[i] = float64(size-i) / float64(size)
-		}
-		for i = 0; i < keys; i++ {
-			copy(b[:], a[:])
-			binary.BigEndian.PutUint64(key, i+size)
-			hash := Hash(key)
-			SortSliceByWeightValue(b[:], w[:], hash)
-			result[b[0]]++
-		}
-
-		for i := 0; i < size-1; i++ {
-			require.True(t, bool(w[i] > w[i+1]) == bool(result[i] > result[i+1]),
-				"result array %v must be corresponded to weights %v", result, w)
-		}
-	})
-
-	t.Run("sortByWeightValueShuffledWeight", func(t *testing.T) {
-		var (
-			i            uint64
-			a, b, result [size]int
-			w            [size]float64
-			key          = make([]byte, 16)
-		)
-
-		for i = 0; i < size; i++ {
-			a[i] = int(i)
-			w[i] = float64(size-i) / float64(size)
-		}
-
-		rand.Shuffle(size, func(i, j int) {
-			w[i], w[j] = w[j], w[i]
-		})
-		for i = 0; i < keys; i++ {
-			copy(b[:], a[:])
-			binary.BigEndian.PutUint64(key, i+size)
-			hash := Hash(key)
-			SortSliceByWeightValue(b[:], w[:], hash)
-			result[b[0]]++
-		}
-		for i := 0; i < size-1; i++ {
-			require.True(t, bool(w[i] > w[i+1]) == bool(result[i] > result[i+1]),
-				"result array %v must be corresponded to weights %v", result, w)
-		}
-	})
-
-	t.Run("sortByWeightValueEmptyWeight", func(t *testing.T) {
-		var (
-			i      uint64
-			a, b   [size]int
-			w      [size]float64
-			counts = make(map[int]int, size)
-			key    = make([]byte, 16)
-		)
-
-		for i = 0; i < size; i++ {
-			a[i] = int(i)
-		}
-
-		for i = 0; i < keys; i++ {
-			copy(b[:], a[:])
-			binary.BigEndian.PutUint64(key, i+size)
-			hash := Hash(key)
-			SortSliceByWeightValue(b[:], w[:], hash)
-			counts[b[0]]++
-		}
-
-		var chi2 float64
-		mean := float64(keys) / float64(size)
-		delta := mean * percent
-		for node, count := range counts {
-			d := mean - float64(count)
-			chi2 += math.Pow(float64(count)-mean, 2) / mean
-			require.True(t, d < delta && (0-d) < delta,
-				"Node %d received %d keys, expected %.0f (+/- %.2f)", node, count, mean, delta)
-		}
-		require.True(t, chi2 < chiTable[size-1],
-			"Chi2 condition for .9 is not met (expected %.2f <= %.2f)", chi2, chiTable[size-1])
-	})
-
-	t.Run("sortByWeightValueUniformWeight", func(t *testing.T) {
-		var (
-			i      uint64
-			a, b   [size]int
-			w      [size]float64
-			counts = make(map[int]int, size)
-			key    = make([]byte, 16)
-		)
-
-		for i = 0; i < size; i++ {
-			a[i] = int(i)
-			w[i] = 0.5
-		}
-
-		for i = 0; i < keys; i++ {
-			copy(b[:], a[:])
-			binary.BigEndian.PutUint64(key, i+size)
-			hash := Hash(key)
-			SortSliceByWeightValue(b[:], w[:], hash)
-			counts[b[0]]++
-		}
-
-		var chi2 float64
-		mean := float64(keys) / float64(size)
-		delta := mean * percent
-		for node, count := range counts {
-			d := mean - float64(count)
-			chi2 += math.Pow(float64(count)-mean, 2) / mean
-			require.True(t, d < delta && (0-d) < delta,
-				"Node %d received %d keys, expected %.0f (+/- %.2f)", node, count, mean, delta)
-		}
-		require.True(t, chi2 < chiTable[size-1],
-			"Chi2 condition for .9 is not met (expected %.2f <= %.2f)", chi2, chiTable[size-1])
-	})
-
-	t.Run("sortByWeightValueAbsoluteW", func(t *testing.T) {
-		const keys = 1
-		var (
-			i    uint64
-			a, b [size]int
-			w    [size]float64
-			key  = make([]byte, 16)
-		)
-
-		for i = 0; i < size; i++ {
-			a[i] = int(i)
-		}
-		w[size-1] = 1
-
-		for i = 0; i < keys; i++ {
-			copy(b[:], a[:])
-			binary.BigEndian.PutUint64(key, i+size)
-			hash := Hash(key)
-			SortSliceByWeightValue(b[:], w[:], hash)
-			require.True(t, b[0] == a[size-1],
-				"expected last value of %v to be the first with highest distance", a)
-		}
-
-	})
-
-	t.Run("sortByWeightValueNormalizedWeight", func(t *testing.T) {
-		var (
-			i              uint64
-			a, b, result   [size]uint64
-			w, normalizedW [size]float64
-			key            = make([]byte, 16)
-		)
-
-		for i = 0; i < size; i++ {
-			a[i] = i
-			w[int(i)] = 10
-		}
-		w[0] = 100
-
-		// Here let's use logarithm normalization
-		for i = 0; i < size; i++ {
-			normalizedW[i] = math.Log2(w[i]) / math.Log2(w[0])
-		}
-
-		for i = 0; i < keys; i++ {
-			copy(b[:], a[:])
-			binary.BigEndian.PutUint64(key, i+size)
-			hash := Hash(key)
-			SortSliceByWeightValue(b[:], normalizedW[:], hash)
-			for j := range b {
-				result[b[j]] += uint64(len(b) - j)
-			}
-		}
-		cutResult := result[1:]
-		var total uint64
-		for i := range cutResult {
-			total += cutResult[i]
-		}
-
-		var chi2 float64
-		mean := float64(total) / float64(len(cutResult))
-		delta := mean * percent
-		for node, count := range cutResult {
 			d := mean - float64(count)
 			chi2 += math.Pow(float64(count)-mean, 2) / mean
 			require.True(t, d < delta && (0-d) < delta,
@@ -579,7 +121,7 @@ func TestDistribution(t *testing.T) {
 
 		for i = 0; i < keys; i++ {
 			binary.BigEndian.PutUint64(key, i+size)
-			hash := Hash(key)
+			hash := WrapBytes(key).Hash()
 			counts[hash]++
 		}
 
@@ -589,188 +131,4 @@ func TestDistribution(t *testing.T) {
 			}
 		}
 	})
-}
-
-func BenchmarkSort_fnv_10(b *testing.B) {
-	hash := Hash(testKey)
-	_ = benchmarkSort(b, 10, hash)
-}
-
-func BenchmarkSort_fnv_100(b *testing.B) {
-	hash := Hash(testKey)
-	_ = benchmarkSort(b, 100, hash)
-}
-
-func BenchmarkSort_fnv_1000(b *testing.B) {
-	hash := Hash(testKey)
-	_ = benchmarkSort(b, 1000, hash)
-}
-
-func BenchmarkSortByIndex_fnv_10(b *testing.B) {
-	hash := Hash(testKey)
-	benchmarkSortByIndex(b, 10, hash)
-}
-
-func BenchmarkSortByIndex_fnv_100(b *testing.B) {
-	hash := Hash(testKey)
-	benchmarkSortByIndex(b, 100, hash)
-}
-
-func BenchmarkSortByIndex_fnv_1000(b *testing.B) {
-	hash := Hash(testKey)
-	benchmarkSortByIndex(b, 1000, hash)
-}
-
-func BenchmarkSortByValue_fnv_10(b *testing.B) {
-	hash := Hash(testKey)
-	benchmarkSortByValue(b, 10, hash)
-}
-
-func BenchmarkSortByValue_fnv_100(b *testing.B) {
-	hash := Hash(testKey)
-	benchmarkSortByValue(b, 100, hash)
-}
-
-func BenchmarkSortByValue_fnv_1000(b *testing.B) {
-	hash := Hash(testKey)
-	benchmarkSortByValue(b, 1000, hash)
-}
-
-func BenchmarkSortByWeight_fnv_10(b *testing.B) {
-	hash := Hash(testKey)
-	_ = benchmarkSortByWeight(b, 10, hash)
-}
-
-func BenchmarkSortByWeight_fnv_100(b *testing.B) {
-	hash := Hash(testKey)
-	_ = benchmarkSortByWeight(b, 100, hash)
-}
-
-func BenchmarkSortByWeight_fnv_1000(b *testing.B) {
-	hash := Hash(testKey)
-	_ = benchmarkSortByWeight(b, 1000, hash)
-}
-
-func BenchmarkSortByWeightIndex_fnv_10(b *testing.B) {
-	hash := Hash(testKey)
-	benchmarkSortByWeightIndex(b, 10, hash)
-}
-
-func BenchmarkSortByWeightIndex_fnv_100(b *testing.B) {
-	hash := Hash(testKey)
-	benchmarkSortByWeightIndex(b, 100, hash)
-}
-
-func BenchmarkSortByWeightIndex_fnv_1000(b *testing.B) {
-	hash := Hash(testKey)
-	benchmarkSortByWeightIndex(b, 1000, hash)
-}
-
-func BenchmarkSortByWeightValue_fnv_10(b *testing.B) {
-	hash := Hash(testKey)
-	benchmarkSortByWeightValue(b, 10, hash)
-}
-
-func BenchmarkSortByWeightValue_fnv_100(b *testing.B) {
-	hash := Hash(testKey)
-	benchmarkSortByWeightValue(b, 100, hash)
-}
-
-func BenchmarkSortByWeightValue_fnv_1000(b *testing.B) {
-	hash := Hash(testKey)
-	benchmarkSortByWeightValue(b, 1000, hash)
-}
-
-func benchmarkSort(b *testing.B, n int, hash uint64) uint64 {
-	servers := make([]uint64, n)
-	for i := uint64(0); i < uint64(len(servers)); i++ {
-		servers[i] = i
-	}
-
-	b.ResetTimer()
-	b.ReportAllocs()
-
-	var x uint64
-	for i := 0; i < b.N; i++ {
-		x += Sort(servers, hash)[0]
-	}
-	return x
-}
-
-func benchmarkSortByIndex(b *testing.B, n int, hash uint64) {
-	servers := make([]uint64, n)
-	for i := uint64(0); i < uint64(len(servers)); i++ {
-		servers[i] = i
-	}
-
-	b.ResetTimer()
-	b.ReportAllocs()
-
-	for i := 0; i < b.N; i++ {
-		SortSliceByIndex(servers, hash)
-	}
-}
-
-func benchmarkSortByValue(b *testing.B, n int, hash uint64) {
-	servers := make([]string, n)
-	for i := uint64(0); i < uint64(len(servers)); i++ {
-		servers[i] = "localhost:" + strconv.FormatUint(60000-i, 10)
-	}
-
-	b.ResetTimer()
-	b.ReportAllocs()
-
-	for i := 0; i < b.N; i++ {
-		SortSliceByValue(servers, hash)
-	}
-}
-
-func benchmarkSortByWeight(b *testing.B, n int, hash uint64) uint64 {
-	servers := make([]uint64, n)
-	weights := make([]float64, n)
-	for i := uint64(0); i < uint64(len(servers)); i++ {
-		weights[i] = float64(uint64(n)-i) / float64(n)
-		servers[i] = i
-	}
-
-	b.ResetTimer()
-	b.ReportAllocs()
-
-	var x uint64
-	for i := 0; i < b.N; i++ {
-		x += SortByWeight(servers, weights, hash)[0]
-	}
-	return x
-}
-
-func benchmarkSortByWeightIndex(b *testing.B, n int, hash uint64) {
-	servers := make([]uint64, n)
-	weights := make([]float64, n)
-	for i := uint64(0); i < uint64(len(servers)); i++ {
-		weights[i] = float64(uint64(n)-i) / float64(n)
-		servers[i] = i
-	}
-
-	b.ResetTimer()
-	b.ReportAllocs()
-
-	for i := 0; i < b.N; i++ {
-		SortSliceByWeightIndex(servers, weights, hash)
-	}
-}
-
-func benchmarkSortByWeightValue(b *testing.B, n int, hash uint64) {
-	servers := make([]string, n)
-	weights := make([]float64, n)
-	for i := uint64(0); i < uint64(len(servers)); i++ {
-		weights[i] = float64(uint64(n)-i) / float64(n)
-		servers[i] = "localhost:" + strconv.FormatUint(60000-i, 10)
-	}
-
-	b.ResetTimer()
-	b.ReportAllocs()
-
-	for i := 0; i < b.N; i++ {
-		SortSliceByWeightValue(servers, weights, hash)
-	}
 }

--- a/v1_test.go
+++ b/v1_test.go
@@ -1,0 +1,80 @@
+package hrw
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Compatibility tests to keep behavior the same
+// compared with the v1-versioned library functions.
+
+func TestSortSliceByIndex(t *testing.T) {
+	actual := []string{"a", "b", "c", "d", "e", "f"}
+	expect := []string{"e", "a", "c", "f", "d", "b"}
+
+	testSlice := stringsToHashAndValueWithIndex(actual)
+	Sort(testSlice, WrapBytes(testKey))
+	result := hashAndValueToStrings(testSlice)
+
+	require.Equal(t, expect, result)
+}
+
+func TestSortSliceByWeightIndex(t *testing.T) {
+	actual := []string{"a", "b", "c", "d", "e", "f"}
+	weights := []float64{1, 1, 1, 0.2, 0.2, 0.2}
+	expect := []string{"a", "c", "b", "e", "f", "d"}
+
+	testSlice := stringsToHashAndValueWithIndex(actual)
+	SortWeighted(testSlice, weights, WrapBytes(testKey))
+	result := hashAndValueToStrings(testSlice)
+
+	require.Equal(t, expect, result)
+}
+
+func TestSortSliceByValue(t *testing.T) {
+	actual := []string{"a", "b", "c", "d", "e", "f"}
+	expect := []string{"d", "f", "c", "b", "a", "e"}
+
+	testSlice := stringsToHashAndValueWithValue(actual)
+	Sort(testSlice, WrapBytes(testKey))
+	result := hashAndValueToStrings(testSlice)
+
+	require.Equal(t, expect, result)
+}
+
+type hashAndValue struct {
+	hash uint64
+	val  string
+}
+
+func (h hashAndValue) Hash() uint64 {
+	return h.hash
+}
+
+func stringsToHashAndValueWithIndex(ss []string) []hashAndValue {
+	res := make([]hashAndValue, 0, len(ss))
+	for i, s := range ss {
+		res = append(res, hashAndValue{hash: uint64(i), val: s})
+	}
+
+	return res
+}
+
+func stringsToHashAndValueWithValue(ss []string) []hashAndValue {
+	res := make([]hashAndValue, 0, len(ss))
+	for _, s := range ss {
+		res = append(res, hashAndValue{hash: WrapBytes([]byte(s)).Hash(), val: s})
+	}
+
+	return res
+}
+
+func hashAndValueToStrings(ss []hashAndValue) []string {
+	res := make([]string, 0, len(ss))
+	for _, s := range ss {
+		res = append(res, s.val)
+	}
+
+	return res
+}


### PR DESCRIPTION
PrePR. Let's discuss API and other things.

```
goos: linux
goarch: amd64
pkg: github.com/nspcc-dev/hrw
cpu: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz
                        │    old.txt    │               new.txt                │
                        │    sec/op     │    sec/op     vs base                │
Sort_fnv_10-8              272.4n ±  6%   136.6n ± 20%  -49.83% (p=0.000 n=10)
Sort_fnv_100-8             2.828µ ±  3%   1.004µ ± 16%  -64.49% (p=0.000 n=10)
Sort_fnv_1000-8           70.387µ ±  0%   8.737µ ±  2%  -87.59% (p=0.000 n=10)
SortByWeight_fnv_10-8      363.4n ±  6%   139.5n ±  3%  -61.61% (p=0.000 n=10)
SortByWeight_fnv_100-8     1.442µ ± 31%   1.018µ ±  3%  -29.44% (p=0.000 n=10)
SortByWeight_fnv_1000-8    11.32µ ±  9%   10.19µ ± 18%   -9.95% (p=0.050 n=10)
geomean                    2.617µ         1.096µ        -58.12%

                        │    old.txt    │               new.txt                │
                        │     B/op      │     B/op      vs base                │
Sort_fnv_10-8                216.0 ± 0%     128.0 ± 0%  -40.74% (p=0.000 n=10)
Sort_fnv_100-8              1848.0 ± 0%     944.0 ± 0%  -48.92% (p=0.000 n=10)
Sort_fnv_1000-8           16.055Ki ± 0%   8.047Ki ± 0%  -49.88% (p=0.000 n=10)
SortByWeight_fnv_10-8        448.0 ± 0%     128.0 ± 0%  -71.43% (p=0.000 n=10)
SortByWeight_fnv_100-8      2896.0 ± 0%     944.0 ± 0%  -67.40% (p=0.000 n=10)
SortByWeight_fnv_1000-8   24.203Ki ± 0%   8.047Ki ± 0%  -66.75% (p=0.000 n=10)
geomean                    2.383Ki          998.5       -59.08%

                        │  old.txt   │              new.txt               │
                        │ allocs/op  │ allocs/op   vs base                │
Sort_fnv_10-8             4.000 ± 0%   2.000 ± 0%  -50.00% (p=0.000 n=10)
Sort_fnv_100-8            4.000 ± 0%   2.000 ± 0%  -50.00% (p=0.000 n=10)
Sort_fnv_1000-8           4.000 ± 0%   2.000 ± 0%  -50.00% (p=0.000 n=10)
SortByWeight_fnv_10-8     8.000 ± 0%   2.000 ± 0%  -75.00% (p=0.000 n=10)
SortByWeight_fnv_100-8    8.000 ± 0%   2.000 ± 0%  -75.00% (p=0.000 n=10)
SortByWeight_fnv_1000-8   8.000 ± 0%   2.000 ± 0%  -75.00% (p=0.000 n=10)
geomean                   5.657        2.000       -64.64%
```